### PR TITLE
Fixing issue which caused destination address logging to be lost

### DIFF
--- a/webroot/index.cgi
+++ b/webroot/index.cgi
@@ -211,7 +211,7 @@ sub getResponse {
         return "Please wait $wait seconds before sending another command.";
     }
 
-    Logger::addEntry($logfile, $remoteIP, $device, $command . " " . $arguments);
+    Logger::addEntry($logfile, $remoteIP, $device->{'address'}, $command . " " . $arguments);
     if (!validCommand($command, $arguments, $device)) {
         return "Disabled Command.";
     }


### PR DESCRIPTION
A bug was introduced that logged something like `HASH(0x4045bb8)` in
place of the expected destination address. The destination ip address
is now logged as expected.