### PR TITLE
SCTASK0053674 reverse arista output

### DIFF
--- a/lib/GRNOC/RouterProxy.pm
+++ b/lib/GRNOC/RouterProxy.pm
@@ -1200,7 +1200,6 @@ sub aristaSSH {
   }
 
   $buf = reverse($buf);
-  $buf = reverse($buf);
   #remove last line (prompt)
   $buf =~ s/.*\n//;
   $buf = reverse($buf);


### PR DESCRIPTION
output from arista was reversed one too many times. Which caused
output to be be backwards. Removed extra reveral.